### PR TITLE
scale/zoom RPM lights to upper RPM band

### DIFF
--- a/LmpGUI.py
+++ b/LmpGUI.py
@@ -164,8 +164,6 @@ def drawRPMLights():
 	minRPMNorm = minRPMRel / 100.0
 	currentRPM = ac.getCarState(0, acsys.CS.RPM)
 	numberOfLights = round(12 * ((currentRPM / maxRPM) - minRPMNorm) / (1 - minRPMNorm))
-	if numberOfLights < 0:
-		numberOfLights = 0
 
 	numberOfLights = min(numberOfLights, 12)
 

--- a/LmpGUI.py
+++ b/LmpGUI.py
@@ -99,7 +99,7 @@ def loadSettings():
 	scale = config.getfloat("LMPGUI", "scale")
 	indicatorsON = config.getboolean("LMPGUI", "indicatorsON")
 	speedInMPH = config.getboolean("LMPGUI", "speedInMPH")
-	minRPMRel = config.getint("LMPGUI", "minRPMRel")
+	minRPMRel = config.getfloat("LMPGUI", "minRPMRel")
 
 def saveSettings():
 	global config, scale, indicatorsON
@@ -161,9 +161,8 @@ def getSpeed():
 def drawRPMLights():
 	global scale, maxRPM, minRPMRel
 
-	minRPMNorm = minRPMRel / 100.0
 	currentRPM = ac.getCarState(0, acsys.CS.RPM)
-	numberOfLights = round(12 * ((currentRPM / maxRPM) - minRPMNorm) / (1 - minRPMNorm))
+	numberOfLights = round(12 * ((currentRPM / maxRPM) - minRPMRel) / (1 - minRPMRel))
 
 	numberOfLights = min(numberOfLights, 12)
 

--- a/LmpGUI.py
+++ b/LmpGUI.py
@@ -61,6 +61,7 @@ fuelAmountStart = 0
 totalFuelBurnt = 0
 
 maxRPM = 0
+minRPMRel = 0
 hasERSorKERS = 0
 
 drsAvailable = 0
@@ -93,11 +94,12 @@ timer10perSecond = 0
 timer1perSecond = 0
 
 def loadSettings():
-	global config, scale, indicatorsON, speedInMPH
+	global config, scale, indicatorsON, speedInMPH, minRPMRel
 
 	scale = config.getfloat("LMPGUI", "scale")
 	indicatorsON = config.getboolean("LMPGUI", "indicatorsON")
 	speedInMPH = config.getboolean("LMPGUI", "speedInMPH")
+	minRPMRel = config.getint("LMPGUI", "minRPMRel")
 
 def saveSettings():
 	global config, scale, indicatorsON
@@ -105,6 +107,7 @@ def saveSettings():
 	config.set("LMPGUI", "scale", str(scale))
 	config.set("LMPGUI", "indicatorsON", str(indicatorsON))
 	config.set("LMPGUI", "speedInMPH", str(speedInMPH))
+	config.set("LMPGUI", "minRPMRel", str(minRPMRel))
 
 	with open(configPath, "w") as configFile:
 	    config.write(configFile)
@@ -149,9 +152,13 @@ def getSpeed():
 	return ac.getCarState(0, acsys.CS.SpeedMPH) if speedInMPH else ac.getCarState(0, acsys.CS.SpeedKMH)
 
 def drawRPMLights():
-	global scale, maxRPM
+	global scale, maxRPM, minRPMRel
 
-	numberOfLights = int(ac.getCarState(0, acsys.CS.RPM) * 12 / maxRPM)
+	minRPMNorm = minRPMRel / 100.0
+	currentRPM = ac.getCarState(0, acsys.CS.RPM)
+	numberOfLights = round(12 * ((currentRPM / maxRPM) - minRPMNorm) / (1 - minRPMNorm))
+	if numberOfLights < 0:
+		numberOfLights = 0
 
 	for i in range(numberOfLights):
 		if i < 6:

--- a/settings.ini
+++ b/settings.ini
@@ -2,4 +2,4 @@
 scale = 0.8
 indicatorsON = true
 speedInMPH = false
-minrpmrel = 0
+minrpmrel = 20

--- a/settings.ini
+++ b/settings.ini
@@ -2,3 +2,4 @@
 scale = 0.8
 indicatorsON = true
 speedInMPH = false
+minrpmrel = 0

--- a/settings.ini
+++ b/settings.ini
@@ -2,4 +2,4 @@
 scale = 0.8
 indicatorsON = true
 speedInMPH = false
-minrpmrel = 20
+minrpmrel = 0.2


### PR DESCRIPTION
- lowest RPM value adjustable by 'minrpmrel' parameter in settings.ini [in percent]
- also using round() to display last RPM light before reaching exactly 100% maxRPM